### PR TITLE
add ecc support in httpapi_compact

### DIFF
--- a/adapters/httpapi_compact.c
+++ b/adapters/httpapi_compact.c
@@ -1295,7 +1295,7 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
         }
 #endif // DO_NOT_COPY_TRUSTED_CERTS_STRING
     }
-    else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0)
+    else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0 || strcmp(OPTION_X509_ECC_CERT, optionName) == 0)
     {
         int len;
         if (http_instance->x509ClientCertificate)
@@ -1318,7 +1318,7 @@ HTTPAPI_RESULT HTTPAPI_SetOption(HTTP_HANDLE handle, const char* optionName, con
             result = HTTPAPI_OK;
         }
     }
-    else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0)
+    else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0 || strcmp(OPTION_X509_ECC_KEY, optionName) == 0)
     {
         int len;
         if (http_instance->x509ClientPrivateKey)
@@ -1391,7 +1391,7 @@ HTTPAPI_RESULT HTTPAPI_CloneOption(const char* optionName, const void* value, co
         }
 #endif // DO_NOT_COPY_TRUSTED_CERTS_STRING
     }
-    else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0)
+    else if (strcmp(SU_OPTION_X509_CERT, optionName) == 0 || strcmp(OPTION_X509_ECC_CERT, optionName) == 0)
     {
         certLen = strlen((const char*)value);
         tempCert = (char*)malloc((certLen + 1) * sizeof(char));
@@ -1408,7 +1408,7 @@ HTTPAPI_RESULT HTTPAPI_CloneOption(const char* optionName, const void* value, co
             result = HTTPAPI_OK;
         }
     }
-    else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0)
+    else if (strcmp(SU_OPTION_X509_PRIVATE_KEY, optionName) == 0 || strcmp(OPTION_X509_ECC_KEY, optionName) == 0)
     {
         certLen = strlen((const char*)value);
         tempCert = (char*)malloc((certLen + 1) * sizeof(char));


### PR DESCRIPTION
Hi,

This PR is designed to add ECC support for httpapi_compact. It is similar to the one made for curl ([#120](https://github.com/Azure/azure-c-shared-utility/pull/120))

The underlying function in X509_schannel.c handle the RSA and ECC certificates but the options were missing in the SetOption and CloneOption functions of httpapi_compact implementation of HTTPAPI.